### PR TITLE
feat: Allow all file types in file picker

### DIFF
--- a/main.html
+++ b/main.html
@@ -25,7 +25,7 @@
         <h1>AI Studio File Reader</h1>
         <p>Select or drag and drop an exported AI Studio file to convert it.</p>
         <div class="upload-area" id="uploadArea">
-            <input type="file" id="fileInput" hidden accept=".json">
+            <input type="file" id="fileInput" hidden>
             <button id="uploadButton">Select File</button>
             <p id="fileName">No file selected</p>
         </div>


### PR DESCRIPTION
The file picker was previously configured to only accept '.json' files. This change removes the 'accept' attribute from the file input element, allowing users to select any file type. This is necessary because Google AI Studio files do not have a file extension.