### PR TITLE
feat: add setting to toggle inclusion of thought process in markdown …

### DIFF
--- a/main.html
+++ b/main.html
@@ -85,6 +85,7 @@
                 </select></div>
             <div class="setting-item"><label for="wrapInCodeBlock"><input type="checkbox" id="wrapInCodeBlock">Wrap
                     content in code blocks </label></div>
+            <div class="setting-item"><label for="includeThoughtProcess"><input type="checkbox" id="includeThoughtProcess" checked>Include thought process</label></div>
         </div>
         <div class="upload-area" id="uploadArea"><input type="file" id="fileInput" hidden><button
                 id="uploadButton">Select File</button>

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const roleHeaderLevelSelect = document.getElementById('roleHeaderLevel');
     const topContentHeaderLevelSelect = document.getElementById('topContentHeaderLevel');
     const wrapInCodeBlockCheckbox = document.getElementById('wrapInCodeBlock');
+    const includeThoughtProcessCheckbox = document.getElementById('includeThoughtProcess');
 
     // --- Event Listeners ---
 
@@ -19,7 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const settings = {
             roleHeaderLevel: roleHeaderLevelSelect.value,
             topContentHeaderLevel: topContentHeaderLevelSelect.value,
-            wrapInCodeBlock: wrapInCodeBlockCheckbox.checked
+            wrapInCodeBlock: wrapInCodeBlockCheckbox.checked,
+            includeThoughtProcess: includeThoughtProcessCheckbox.checked
         };
         localStorage.setItem('aiStudioReaderSettings', JSON.stringify(settings));
     };
@@ -31,12 +33,14 @@ document.addEventListener('DOMContentLoaded', () => {
             roleHeaderLevelSelect.value = settings.roleHeaderLevel || '3';
             topContentHeaderLevelSelect.value = settings.topContentHeaderLevel || '0';
             wrapInCodeBlockCheckbox.checked = settings.wrapInCodeBlock || false;
+            includeThoughtProcessCheckbox.checked = settings.includeThoughtProcess !== undefined ? settings.includeThoughtProcess : true;
         }
     };
 
     roleHeaderLevelSelect.addEventListener('change', saveSettings);
     topContentHeaderLevelSelect.addEventListener('change', saveSettings);
     wrapInCodeBlockCheckbox.addEventListener('change', saveSettings);
+    includeThoughtProcessCheckbox.addEventListener('change', saveSettings);
 
     // Initialize settings
     loadSettings();
@@ -106,6 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const roleHeaderLevel = parseInt(roleHeaderLevelSelect.value, 10);
         const topContentHeaderLevel = parseInt(topContentHeaderLevelSelect.value, 10);
         const wrapInCodeBlock = wrapInCodeBlockCheckbox.checked;
+        const includeThoughtProcess = includeThoughtProcessCheckbox.checked;
         const roleHeaderHashes = '#'.repeat(roleHeaderLevel);
 
         let md = `# Conversation Log from ${originalName}\n\n`;
@@ -116,6 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const isThought = chunk.isThought || false;
 
             if (!text) return;
+            if (isThought && !includeThoughtProcess) return;
 
             // Apply content transformations
             if (wrapInCodeBlock) {

--- a/test_logic.js
+++ b/test_logic.js
@@ -2,12 +2,14 @@
 const roleHeaderLevelSelect = { value: '3' };
 const topContentHeaderLevelSelect = { value: '0' };
 const wrapInCodeBlockCheckbox = { checked: false };
+const includeThoughtProcessCheckbox = { checked: true };
 
 // Mock convertToMarkdown function (copied from main.js with minor adjustments for node)
 const convertToMarkdown = (data, originalName) => {
     const roleHeaderLevel = parseInt(roleHeaderLevelSelect.value, 10);
     const topContentHeaderLevel = parseInt(topContentHeaderLevelSelect.value, 10);
     const wrapInCodeBlock = wrapInCodeBlockCheckbox.checked;
+    const includeThoughtProcess = includeThoughtProcessCheckbox.checked;
     const roleHeaderHashes = '#'.repeat(roleHeaderLevel);
 
     let md = `# Conversation Log from ${originalName}\n\n`;
@@ -18,6 +20,7 @@ const convertToMarkdown = (data, originalName) => {
         const isThought = chunk.isThought || false;
 
         if (!text) return;
+        if (isThought && !includeThoughtProcess) return;
 
         // Apply content transformations
         if (wrapInCodeBlock) {
@@ -108,3 +111,26 @@ roleHeaderLevelSelect.value = '3';
 topContentHeaderLevelSelect.value = '1'; // Shift +1
 wrapInCodeBlockCheckbox.checked = false;
 console.log(convertToMarkdown(overflowData, 'Test5'));
+
+// Test 6: Thought Process Omission
+console.log('\n--- Test 6: Thought Process Omission ---');
+const thoughtData = {
+    chunkedPrompt: {
+        chunks: [
+            { role: 'user', text: 'Ask a hard question' },
+            { role: 'model', text: 'Thinking step 1...\nThinking step 2...', isThought: true },
+            { role: 'model', text: 'The answer is 42.' }
+        ]
+    }
+};
+roleHeaderLevelSelect.value = '3';
+topContentHeaderLevelSelect.value = '0';
+wrapInCodeBlockCheckbox.checked = false;
+
+console.log('--- Test 6a: With Thought Process (Default) ---');
+includeThoughtProcessCheckbox.checked = true;
+console.log(convertToMarkdown(thoughtData, 'Test6a'));
+
+console.log('--- Test 6b: Without Thought Process ---');
+includeThoughtProcessCheckbox.checked = false;
+console.log(convertToMarkdown(thoughtData, 'Test6b'));


### PR DESCRIPTION
…output\n\n- Added `includeThoughtProcess` checkbox to `main.html`.\n- Updated `main.js` to save and load the new setting from localStorage.\n- Modified `convertToMarkdown` logic to skip `isThought` chunks when the setting is disabled.\n- Added a new test case to `test_logic.js` to verify the new behavior.\n- Maintained backward compatibility by defaulting the setting to true.